### PR TITLE
add option to exclude docks from tinting

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1197,6 +1197,24 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         QMatrix4x4 projectionMatrix;
         projectionMatrix.ortho(QRectF(0.0, 0.0, deviceBackgroundRect.width(), deviceBackgroundRect.height()));
 
+        // Set tint uniforms
+        const bool excludeDocks(m_settings.general.excludeDocks);
+        QColor tint(m_settings.general.tintColor);
+        QVector3D tintVec(tint.redF(),tint.greenF(),tint.blueF());
+        float tintStrength = excludeDocks && w->isDock() ? 0.0 : tint.alphaF();
+        m_upsamplePass.shader->setUniform(m_upsamplePass.tintColorLocation, tintVec);
+        m_upsamplePass.shader->setUniform(m_upsamplePass.tintStrengthLocation, tintStrength);
+
+        // Set glow uniforms
+        QColor glow(m_settings.general.glowColor);
+        QVector3D glowVec(glow.redF(),glow.greenF(),glow.blueF());
+        float glowStrength = glow.alphaF();
+        m_upsamplePass.shader->setUniform(m_upsamplePass.glowColorLocation, glowVec);
+        m_upsamplePass.shader->setUniform(m_upsamplePass.glowStrengthLocation, glowStrength);
+
+        // Set edge lighting (brightness)
+        const bool edgeLighting(m_settings.general.edgeLighting);
+        m_upsamplePass.shader->setUniform(m_upsamplePass.edgeLightingLocation, static_cast<int>(edgeLighting));
         m_upsamplePass.shader->setUniform(m_upsamplePass.topCornerRadiusLocation, static_cast<float>(0));
         m_upsamplePass.shader->setUniform(m_upsamplePass.bottomCornerRadiusLocation, static_cast<float>(0));
         m_upsamplePass.shader->setUniform(m_upsamplePass.mvpMatrixLocation, projectionMatrix);
@@ -1242,23 +1260,6 @@ void BlurEffect::blur(BlurRenderData &renderInfo, const RenderTarget &renderTarg
         m_upsamplePass.shader->setUniform(m_upsamplePass.bottomCornerRadiusLocation, bottomCornerRadius);
         m_upsamplePass.shader->setUniform(m_upsamplePass.blurSizeLocation, QVector2D(deviceBackgroundRect.width(), deviceBackgroundRect.height()));
         m_upsamplePass.shader->setUniform(m_upsamplePass.opacityLocation, static_cast<float>(opacity));
-        // Set tint uniforms
-        QColor tint(m_settings.general.tintColor);
-        QVector3D tintVec(tint.redF(),tint.greenF(),tint.blueF());
-        float tintStrength = tint.alphaF();
-        m_upsamplePass.shader->setUniform(m_upsamplePass.tintColorLocation, tintVec);
-        m_upsamplePass.shader->setUniform(m_upsamplePass.tintStrengthLocation, tintStrength);
-
-        // Set glow uniforms
-        QColor glow(m_settings.general.glowColor);
-        QVector3D glowVec(glow.redF(),glow.greenF(),glow.blueF());
-        float glowStrength = glow.alphaF();
-        m_upsamplePass.shader->setUniform(m_upsamplePass.glowColorLocation, glowVec);
-        m_upsamplePass.shader->setUniform(m_upsamplePass.glowStrengthLocation, glowStrength);
-
-        // Set edge lighting (brightness)
-        const bool edgeLighting(m_settings.general.edgeLighting);
-        m_upsamplePass.shader->setUniform(m_upsamplePass.edgeLightingLocation, static_cast<int>(edgeLighting));
 
         projectionMatrix = viewport.projectionMatrix();
         projectionMatrix.translate(scaledBackgroundRect.x(), scaledBackgroundRect.y());

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -8,6 +8,9 @@
         <entry name="EdgeLighting" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="ExcludeDocks" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="TintColor" type="String">
             <default>#00000000</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -288,11 +288,22 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="kcfg_EdgeLighting">
-         <property name="text">
-          <string>Make the window edges brighter</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QCheckBox" name="kcfg_EdgeLighting">
+           <property name="text">
+            <string>Make the window edges brighter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="kcfg_ExcludeDocks">
+           <property name="text">
+            <string>Don't apply tint to docks</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QWidget" name="widget" native="true">
@@ -366,7 +377,7 @@
          </property>
         </widget>
        </item>
-			 <!--
+       <!--
        <item>
         <widget class="QCheckBox" name="kcfg_BlurMenus">
          <property name="text">
@@ -381,7 +392,7 @@
          </property>
         </widget>
        </item>
-			 -->
+       -->
       </layout>
      </widget>
      <widget class="QWidget" name="widget">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -16,6 +16,7 @@ void BlurSettings::read()
     general.tintColor = BlurConfig::tintColor();
     general.glowColor = BlurConfig::glowColor();
     general.edgeLighting = BlurConfig::edgeLighting();
+    general.excludeDocks = BlurConfig::excludeDocks();
 
     forceBlur.windowClasses.clear();
     const auto blank = QStringLiteral("blank");

--- a/src/settings.h
+++ b/src/settings.h
@@ -29,6 +29,7 @@ struct GeneralSettings
     QString tintColor;
     QString glowColor;
     bool edgeLighting;
+    bool excludeDocks;
 };
 
 struct ForceBlurSettings

--- a/src/shaders/upsample.glsl
+++ b/src/shaders/upsample.glsl
@@ -44,7 +44,7 @@ void main(void)
     if (refractionStrength > 0 && minHalfSize >= 16.0) {
 
         vec2 position = uv * blurSize - halfBlurSize.xy;
-        float dist = roundedRectangleDist(position, halfBlurSize, topCornerRadius, bottomCornerRadius) * 0.80;
+        float dist = roundedRectangleDist(position, halfBlurSize, topCornerRadius, bottomCornerRadius);
 
         float minEsp = max(min(edgeSizePixels, minHalfSize), 0.1);
         float edgeFactor = 1.0 - clamp(abs(dist) / minEsp, 0.0, 1.0);

--- a/src/shaders/upsample_core.glsl
+++ b/src/shaders/upsample_core.glsl
@@ -47,7 +47,7 @@ void main(void)
     if (refractionStrength > 0 && minHalfSize >= 16.0) {
 
         vec2 position = uv * blurSize - halfBlurSize.xy;
-        float dist = roundedRectangleDist(position, halfBlurSize, topCornerRadius, bottomCornerRadius) * 0.80;
+        float dist = roundedRectangleDist(position, halfBlurSize, topCornerRadius, bottomCornerRadius);
 
         float minEsp = max(min(edgeSizePixels, minHalfSize), 0.1);
         float edgeFactor = 1.0 - clamp(abs(dist) / minEsp, 0.0, 1.0);


### PR DESCRIPTION
This allows the docks to have that  full glass effect while allowing other windows to be tinted to a less transparent appearance.