### PR TITLE
Physically based refraction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,11 @@ add_subdirectory(kcm)
 # Read compat preambles
 file(READ shaders/compat_core.glsl COMPAT_CORE)
 file(READ shaders/compat_legacy.glsl COMPAT_LEGACY)
+file(READ shaders/snells-glass.glsl SNELLS_GLASS_SHADER)
 file(READ shaders/glass.glsl GLASS_SHADER)
+
+# Pre-expand snells-glass.glsl into glass.glsl
+string(REPLACE "#include \"snells-glass.glsl\"" "${SNELLS_GLASS_SHADER}" GLASS_SHADER "${GLASS_SHADER}")
 
 # Generate a core and legacy shader variant from a single .glsl source.
 # Output goes into generated/ to keep source shaders/ clean.

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -124,6 +124,7 @@ BlurEffect::BlurEffect()
         m_roundedOnscreenPass.refractionStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionStrength");
         m_roundedOnscreenPass.refractionNormalPowLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionNormalPow");
         m_roundedOnscreenPass.refractionRGBFringingLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionRGBFringing");
+        m_roundedOnscreenPass.refractionOffsetStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionOffsetStrength");
         m_roundedOnscreenPass.physicallyBasedRefractionLocation = m_roundedOnscreenPass.shader->uniformLocation("physicallyBasedRefraction");
         m_roundedOnscreenPass.tintColorLocation = m_roundedOnscreenPass.shader->uniformLocation("tintColor");
         m_roundedOnscreenPass.tintStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("tintStrength");
@@ -1185,6 +1186,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionStrengthLocation, m_settings.refraction.refractionStrength);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionNormalPowLocation, m_settings.refraction.refractionNormalPow);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionRGBFringingLocation, m_settings.refraction.refractionRGBFringing);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionOffsetStrengthLocation, m_settings.refraction.refractionOffsetStrength);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.physicallyBasedRefractionLocation, m_settings.refraction.physicallyBased ? 1 : 0);
 
     QColor tint(m_settings.general.tintColor);

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -124,6 +124,7 @@ BlurEffect::BlurEffect()
         m_roundedOnscreenPass.refractionStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionStrength");
         m_roundedOnscreenPass.refractionNormalPowLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionNormalPow");
         m_roundedOnscreenPass.refractionRGBFringingLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionRGBFringing");
+        m_roundedOnscreenPass.physicallyBasedRefractionLocation = m_roundedOnscreenPass.shader->uniformLocation("physicallyBasedRefraction");
         m_roundedOnscreenPass.tintColorLocation = m_roundedOnscreenPass.shader->uniformLocation("tintColor");
         m_roundedOnscreenPass.tintStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("tintStrength");
         m_roundedOnscreenPass.glowColorLocation = m_roundedOnscreenPass.shader->uniformLocation("glowColor");
@@ -1184,6 +1185,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionStrengthLocation, m_settings.refraction.refractionStrength);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionNormalPowLocation, m_settings.refraction.refractionNormalPow);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionRGBFringingLocation, m_settings.refraction.refractionRGBFringing);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.physicallyBasedRefractionLocation, m_settings.refraction.physicallyBased ? 1 : 0);
 
     QColor tint(m_settings.general.tintColor);
     QVector3D tintVec(tint.redF(), tint.greenF(), tint.blueF());

--- a/src/blur.h
+++ b/src/blur.h
@@ -147,6 +147,7 @@ private:
         int refractionStrengthLocation;
         int refractionNormalPowLocation;
         int refractionRGBFringingLocation;
+        int refractionOffsetStrengthLocation;
         int physicallyBasedRefractionLocation;
 
         int tintColorLocation;

--- a/src/blur.h
+++ b/src/blur.h
@@ -147,6 +147,7 @@ private:
         int refractionStrengthLocation;
         int refractionNormalPowLocation;
         int refractionRGBFringingLocation;
+        int physicallyBasedRefractionLocation;
 
         int tintColorLocation;
         int tintStrengthLocation;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -115,5 +115,8 @@ class3</default>
         <entry name="RefractionRGBFringing" type="Double">
             <default>1.0</default>
         </entry>
+        <entry name="PhysicallyBasedRefraction" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -115,6 +115,9 @@ class3</default>
         <entry name="RefractionRGBFringing" type="Double">
             <default>1.0</default>
         </entry>
+        <entry name="RefractionOffsetStrength" type="Double">
+            <default>8.0</default>
+        </entry>
         <entry name="PhysicallyBasedRefraction" type="Bool">
             <default>false</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -558,16 +558,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="kcfg_PhysicallyBasedRefraction">
-         <property name="text">
-          <string>Physically based refraction</string>
-         </property>
-         <property name="toolTip">
-          <string>Use a Snell's-law (IOR-based) refraction model instead. The Refraction Strength slider is reinterpreted as the index-of-refraction delta in this mode.</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QLabel" name="labelRefractionStrength">
          <property name="text">
           <string>Refraction Strength:</string>
@@ -832,6 +822,97 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="kcfg_PhysicallyBasedRefraction">
+         <property name="text">
+          <string>Physically based refraction</string>
+         </property>
+         <property name="toolTip">
+          <string>Use a Snell's-law (IOR-based) refraction model instead. The Refraction Strength slider is reinterpreted as the index-of-refraction delta in this mode.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelRefractionOffsetStrength">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Refraction Offset Strength:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutRefractionOffsetStrength">
+         <item>
+          <spacer name="horizontalSpacerRefractionOffsetStrength">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionOffsetStrengthOff">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Off</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="kcfg_RefractionOffsetStrength">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>20</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>8</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TickPosition::TicksBelow</enum>
+           </property>
+           <property name="toolTip">
+            <string>Pulls the IOR-based refraction outward based on position within the window (Snell's-law mode only).</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionOffsetStrengthStrong">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Strong</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -1030,6 +1111,31 @@
    <signal>toggled(bool)</signal>
    <receiver>kcfg_EdgeLightingTooltip</receiver>
    <slot>setChecked(bool)</slot>
+  </connection>
+
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>kcfg_RefractionOffsetStrength</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionOffsetStrength</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionOffsetStrengthOff</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionOffsetStrengthStrong</receiver>
+   <slot>setEnabled(bool)</slot>
   </connection>
  </connections>
 </ui>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -558,6 +558,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="kcfg_PhysicallyBasedRefraction">
+         <property name="text">
+          <string>Physically based refraction</string>
+         </property>
+         <property name="toolTip">
+          <string>Use a Snell's-law (IOR-based) refraction model instead. The Refraction Strength slider is reinterpreted as the index-of-refraction delta in this mode.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="labelRefractionStrength">
          <property name="text">
           <string>Refraction Strength:</string>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -71,6 +71,7 @@ void BlurSettings::read()
     refraction.refractionStrength = BlurConfig::refractionStrength() / 20.0;
     refraction.refractionNormalPow = BlurConfig::refractionNormalPow() / 2.0;
     refraction.refractionRGBFringing = BlurConfig::refractionRGBFringing() / 20.0;
+    refraction.refractionOffsetStrength = BlurConfig::refractionOffsetStrength() / 2.0;
     refraction.physicallyBased = BlurConfig::physicallyBasedRefraction();
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -71,6 +71,7 @@ void BlurSettings::read()
     refraction.refractionStrength = BlurConfig::refractionStrength() / 20.0;
     refraction.refractionNormalPow = BlurConfig::refractionNormalPow() / 2.0;
     refraction.refractionRGBFringing = BlurConfig::refractionRGBFringing() / 20.0;
+    refraction.physicallyBased = BlurConfig::physicallyBasedRefraction();
 }
 
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -56,6 +56,7 @@ struct RefractionSettings
     float refractionStrength;
     float refractionNormalPow;
     float refractionRGBFringing;
+    float refractionOffsetStrength;
     bool physicallyBased;
 };
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -56,6 +56,7 @@ struct RefractionSettings
     float refractionStrength;
     float refractionNormalPow;
     float refractionRGBFringing;
+    bool physicallyBased;
 };
 
 class BlurSettings

--- a/src/shaders/glass.glsl
+++ b/src/shaders/glass.glsl
@@ -8,9 +8,8 @@ uniform float edgeSizePixels;
 uniform float refractionStrength;
 uniform float refractionNormalPow;
 uniform float refractionRGBFringing;
+uniform float refractionOffsetStrength;
 uniform int physicallyBasedRefraction;
-
-#include "snells-glass.glsl"
 
 float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)
 {
@@ -20,6 +19,8 @@ float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)
     vec2 q = abs(p) - b + r;
     return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
 }
+
+#include "snells-glass.glsl"
 
 vec4 roundedRectangle(vec2 fragCoord, vec3 color, vec4 cornerRadius)
 {
@@ -52,9 +53,9 @@ vec4 glass(vec4 sum, vec4 cornerRadius)
     float concaveFactor = 1.0 - sqrt(1.0 - pow(smoothstep(0.0, 1.0, edgeFactor), refractionNormalPow));
 
     if (refractionStrength > 0) {
+        vec4 r = clamp(cornerRadius * 2.0, min(64.0, minHalfSize), min(128.0, minHalfSize));
         if (physicallyBasedRefraction == 0) {
             const float h = 1.0;
-            vec4 r = clamp(cornerRadius * 2.0, min(64.0, minHalfSize), min(128.0, minHalfSize));
             vec2 gradient = vec2(
                     roundedRectangleDist(position + vec2(h, 0), halfBlurSize, r) - roundedRectangleDist(position - vec2(h, 0), halfBlurSize, r),
                     roundedRectangleDist(position + vec2(0, h), halfBlurSize, r) - roundedRectangleDist(position - vec2(0, h), halfBlurSize, r)
@@ -86,7 +87,7 @@ vec4 glass(vec4 sum, vec4 cornerRadius)
             sum.b = TEXTURE(texUnit, coordB).b;
             sum.a = TEXTURE(texUnit, coordG).a;
         } else {
-            sum = snellsRefraction(position, halfBlurSize, cornerRadius, dist);
+            sum = snellsRefraction(position, halfBlurSize, r, minHalfSize, dist);
         }
     }
 

--- a/src/shaders/glass.glsl
+++ b/src/shaders/glass.glsl
@@ -8,6 +8,9 @@ uniform float edgeSizePixels;
 uniform float refractionStrength;
 uniform float refractionNormalPow;
 uniform float refractionRGBFringing;
+uniform int physicallyBasedRefraction;
+
+#include "snells-glass.glsl"
 
 float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)
 {
@@ -49,39 +52,42 @@ vec4 glass(vec4 sum, vec4 cornerRadius)
     float concaveFactor = 1.0 - sqrt(1.0 - pow(smoothstep(0.0, 1.0, edgeFactor), refractionNormalPow));
 
     if (refractionStrength > 0) {
-        // Initial 2D normal
-        const float h = 1.0;
-        vec4 r = clamp(cornerRadius * 2.0, min(64.0, minHalfSize), min(128.0, minHalfSize));
-        vec2 gradient = vec2(
-                roundedRectangleDist(position + vec2(h, 0), halfBlurSize, r) - roundedRectangleDist(position - vec2(h, 0), halfBlurSize, r),
-                roundedRectangleDist(position + vec2(0, h), halfBlurSize, r) - roundedRectangleDist(position - vec2(0, h), halfBlurSize, r)
-        );
+        if (physicallyBasedRefraction == 0) {
+            const float h = 1.0;
+            vec4 r = clamp(cornerRadius * 2.0, min(64.0, minHalfSize), min(128.0, minHalfSize));
+            vec2 gradient = vec2(
+                    roundedRectangleDist(position + vec2(h, 0), halfBlurSize, r) - roundedRectangleDist(position - vec2(h, 0), halfBlurSize, r),
+                    roundedRectangleDist(position + vec2(0, h), halfBlurSize, r) - roundedRectangleDist(position - vec2(0, h), halfBlurSize, r)
+            );
 
-        vec2 normal = length(gradient) > 0.0 ? -normalize(gradient) : vec2(0.0, 1.0);
+            vec2 normal = length(gradient) > 0.0 ? -normalize(gradient) : vec2(0.0, 1.0);
 
-        float finalStrength = min(0.4 * concaveFactor * refractionStrength, 1.0);
+            float finalStrength = min(0.4 * concaveFactor * refractionStrength, 1.0);
 
-        vec2 refractOffsetG = -normal.xy * finalStrength;
-        vec2 refractOffsetR = -normal.xy * finalStrength;
-        vec2 refractOffsetB = -normal.xy * finalStrength;
+            vec2 refractOffsetG = -normal.xy * finalStrength;
+            vec2 refractOffsetR = -normal.xy * finalStrength;
+            vec2 refractOffsetB = -normal.xy * finalStrength;
 
-        // Different refraction offsets for each color channel
-        float fringingFactor = refractionRGBFringing * 0.3;
-        if (fringingFactor > 0.0) {
-            // Red bends most
-            refractOffsetR = -normal.xy * (finalStrength * (1.0 + fringingFactor));
-            // Blue bends least
-            refractOffsetB = -normal.xy * (finalStrength * (1.0 - fringingFactor));
+            // Different refraction offsets for each color channel
+            float fringingFactor = refractionRGBFringing * 0.3;
+            if (fringingFactor > 0.0) {
+                // Red bends most
+                refractOffsetR = -normal.xy * (finalStrength * (1.0 + fringingFactor));
+                // Blue bends least
+                refractOffsetB = -normal.xy * (finalStrength * (1.0 - fringingFactor));
+            }
+
+            vec2 coordR = clamp(uv - refractOffsetR, 0.0, 1.0);
+            vec2 coordG = clamp(uv - refractOffsetG, 0.0, 1.0);
+            vec2 coordB = clamp(uv - refractOffsetB, 0.0, 1.0);
+
+            sum.r = TEXTURE(texUnit, coordR).r;
+            sum.g = TEXTURE(texUnit, coordG).g;
+            sum.b = TEXTURE(texUnit, coordB).b;
+            sum.a = TEXTURE(texUnit, coordG).a;
+        } else {
+            sum = snellsRefraction(position, halfBlurSize, cornerRadius, dist);
         }
-
-        vec2 coordR = clamp(uv - refractOffsetR, 0.0, 1.0);
-        vec2 coordG = clamp(uv - refractOffsetG, 0.0, 1.0);
-        vec2 coordB = clamp(uv - refractOffsetB, 0.0, 1.0);
-
-        sum.r = TEXTURE(texUnit, coordR).r;
-        sum.g = TEXTURE(texUnit, coordG).g;
-        sum.b = TEXTURE(texUnit, coordB).b;
-        sum.a = TEXTURE(texUnit, coordG).a;
     }
 
     if (concaveFactor < 1.0) {

--- a/src/shaders/snells-glass.glsl
+++ b/src/shaders/snells-glass.glsl
@@ -1,0 +1,5 @@
+vec4 snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadius, float dist)
+{
+    return TEXTURE(texUnit, uv);
+}
+f

--- a/src/shaders/snells-glass.glsl
+++ b/src/shaders/snells-glass.glsl
@@ -1,5 +1,60 @@
-vec4 snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadius, float dist)
+// Snell's-law refraction; included into glass.glsl. ior = 1.0 + refractionStrength.
+
+vec4 processSample(sampler2D tex, vec2 baseUv, vec3 glassNormal, float ior,
+                   float dispersion, float bandWidth, vec2 uvScale, vec2 lensShift)
 {
-    return TEXTURE(texUnit, uv);
+    vec3 viewRay = vec3(0.0, 0.0, -1.0);
+
+    vec3 refractG = refract(viewRay, glassNormal, 1.0 / ior);
+    vec2 shiftG = (-refractG.xy / max(abs(refractG.z), 0.001)) * bandWidth * uvScale + lensShift;
+    vec4 sampleG = TEXTURE(tex, clamp(baseUv + shiftG, 0.0, 1.0));
+
+    if (dispersion > 0.001) {
+        vec3 refractR = refract(viewRay, glassNormal, 1.0 / (ior - dispersion));
+        vec2 shiftR = (-refractR.xy / max(abs(refractR.z), 0.001)) * bandWidth * uvScale + lensShift;
+
+        vec3 refractB = refract(viewRay, glassNormal, 1.0 / (ior + dispersion));
+        vec2 shiftB = (-refractB.xy / max(abs(refractB.z), 0.001)) * bandWidth * uvScale + lensShift;
+
+        float r = TEXTURE(tex, clamp(baseUv + shiftR, 0.0, 1.0)).r;
+        float b = TEXTURE(tex, clamp(baseUv + shiftB, 0.0, 1.0)).b;
+        return vec4(r, sampleG.g, b, sampleG.a);
+    }
+    return sampleG;
 }
-f
+
+vec4 snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadius, float minHalfSize, float dist)
+{
+    float bandWidth = clamp(edgeSizePixels, 0.1, minHalfSize * 0.9);
+    float invBandWidth = 1.0 / bandWidth;
+    float ior = 1.0 + refractionStrength;
+
+    float sdfBlend = clamp(-dist / bandWidth, 0.0, 1.0);
+    float sdfProfile = 6.0 * sdfBlend * (1.0 - sdfBlend);
+
+    float eps = bandWidth * 0.75;
+    float dxp = roundedRectangleDist(position + vec2(eps, 0.0), halfBlurSize, cornerRadius);
+    float dxn = roundedRectangleDist(position - vec2(eps, 0.0), halfBlurSize, cornerRadius);
+    float dyp = roundedRectangleDist(position + vec2(0.0, eps), halfBlurSize, cornerRadius);
+    float dyn = roundedRectangleDist(position - vec2(0.0, eps), halfBlurSize, cornerRadius);
+    vec2 smoothGrad = vec2(dxp - dxn, dyp - dyn);
+    float gradLen = length(smoothGrad);
+
+    float normalHeight = min(sdfProfile * refractionNormalPow * 0.08, 1.0);
+    vec2 normalXY = gradLen > 0.001 ? (smoothGrad / gradLen) * normalHeight : vec2(0.0);
+    vec3 glassNormal = normalize(vec3(normalXY, 1.0));
+
+    float lensBlend = 1.0 - smoothstep(0.0, 1.0, -dist * invBandWidth);
+    float lensMagnitude = lensBlend * bandWidth;
+    vec2 surfaceNormal = gradLen > 0.001 ? smoothGrad / gradLen : vec2(1.0, 0.0);
+
+    // Refraction offset: positional outward pull, gated by edge proximity (lensBlend).
+    vec2 normalizedPos = position / blurSize;
+    float cornerWeight = dot(normalizedPos, normalizedPos) * refractionOffsetStrength;
+    surfaceNormal += normalizedPos * lensBlend * cornerWeight;
+
+    vec2 uvScale = 1.0 / blurSize;
+    vec2 lensShift = -surfaceNormal * lensMagnitude * uvScale;
+
+    return processSample(texUnit, uv, glassNormal, ior, refractionRGBFringing, bandWidth, uvScale, lensShift);
+}


### PR DESCRIPTION
A small follow-up that adds an opt-in Snell's-law refraction mode alongside the existing one. Default is unchanged.

### What's new

- Physically based refraction checkbox in the Refraction tab. When on, the existing Refraction Strength slider is reinterpreted as the IOR delta (ior = 1.0 + value).
- Refraction Offset Strength slider for the corner-bending pull. Auto-disables in the UI when the checkbox is off.
- New src/shaders/snells-glass.glsl holds the Snell's-law path; glass.glsl just wraps the existing refraction block in an if/else. The existing path unchanged.