### PR TITLE
Blur finetune slider, symmetric kernels and saturation compensation

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -156,6 +156,7 @@ BlurEffect::BlurEffect()
         m_upsamplePass.mvpMatrixLocation = m_upsamplePass.shader->uniformLocation("modelViewProjectionMatrix");
         m_upsamplePass.offsetLocation = m_upsamplePass.shader->uniformLocation("offset");
         m_upsamplePass.halfpixelLocation = m_upsamplePass.shader->uniformLocation("halfpixel");
+        m_upsamplePass.saturationCompensationLocation = m_upsamplePass.shader->uniformLocation("saturationCompensation");
     }
 
     m_noisePass.shader = ShaderManager::instance()->generateShaderFromFile(ShaderTrait::MapTexture,
@@ -1288,6 +1289,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         m_upsamplePass.shader->setUniform(m_upsamplePass.mvpMatrixLocation, projectionMatrix);
         m_upsamplePass.shader->setUniform(m_upsamplePass.offsetLocation, settings.offset * m_upsampleOffset);
 
+        const float upsampleSaturationBoost = 1.10f + 0.10f * (m_blurRadius + m_upsampleOffset) * 0.5f;
+
         for (size_t i = settings.iterationCount; i > 1; --i) {
             GLFramebuffer::popFramebuffer();
             const auto &read = renderInfo.framebuffers[i];
@@ -1295,6 +1298,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
             const QVector2D halfpixel(0.5 / read->colorAttachment()->width(),
                                       0.5 / read->colorAttachment()->height());
             m_upsamplePass.shader->setUniform(m_upsamplePass.halfpixelLocation, halfpixel);
+            m_upsamplePass.shader->setUniform(m_upsamplePass.saturationCompensationLocation, i == 2 ? upsampleSaturationBoost : 1.0f);
 
             read->colorAttachment()->bind();
 

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1289,7 +1289,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         m_upsamplePass.shader->setUniform(m_upsamplePass.mvpMatrixLocation, projectionMatrix);
         m_upsamplePass.shader->setUniform(m_upsamplePass.offsetLocation, settings.offset * m_upsampleOffset);
 
-        const float upsampleSaturationBoost = 1.10f + 0.10f * (m_blurRadius + m_upsampleOffset) * 0.5f;
+        const float upsampleSaturationBoost = 1.18f + 0.13f * (m_blurRadius + m_upsampleOffset) * 0.5f;
 
         for (size_t i = settings.iterationCount; i > 1; --i) {
             GLFramebuffer::popFramebuffer();

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -325,6 +325,8 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
         m_decorationBlurSettings.expandSize,
         m_dockBlurSettings.expandSize,
     });
+    m_blurRadius = m_settings.general.blurRadius;
+    m_upsampleOffset = m_settings.general.upsampleOffset;
     m_colorMatrix = colorTransformMatrix(
         m_settings.general.saturation,
         m_settings.general.contrast,
@@ -1263,7 +1265,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         projectionMatrix.ortho(QRectF(0.0, 0.0, backgroundRect.width(), backgroundRect.height()));
 
         m_downsamplePass.shader->setUniform(m_downsamplePass.mvpMatrixLocation, projectionMatrix);
-        m_downsamplePass.shader->setUniform(m_downsamplePass.offsetLocation, settings.offset);
+        m_downsamplePass.shader->setUniform(m_downsamplePass.offsetLocation, settings.offset * m_blurRadius);
 
         for (size_t i = 1; i <= settings.iterationCount; ++i) {
             const auto &read = renderInfo.framebuffers[i - 1];
@@ -1284,7 +1286,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         ShaderManager::instance()->pushShader(m_upsamplePass.shader.get());
 
         m_upsamplePass.shader->setUniform(m_upsamplePass.mvpMatrixLocation, projectionMatrix);
-        m_upsamplePass.shader->setUniform(m_upsamplePass.offsetLocation, settings.offset);
+        m_upsamplePass.shader->setUniform(m_upsamplePass.offsetLocation, settings.offset * m_upsampleOffset);
 
         for (size_t i = settings.iterationCount; i > 1; --i) {
             GLFramebuffer::popFramebuffer();
@@ -1332,7 +1334,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.mvpMatrixLocation, projectionMatrix);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.colorMatrixLocation, colorMatrix);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.halfpixelLocation, halfpixel);
-    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.offsetLocation, combinedBlurSettings.offset);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.offsetLocation, combinedBlurSettings.offset * m_upsampleOffset);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.boxLocation, QVector4D(nativeBox.x() + nativeBox.width() * 0.5, nativeBox.y() + nativeBox.height() * 0.5, nativeBox.width() * 0.5, nativeBox.height() * 0.5));
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.cornerRadiusLocation, nativeCornerRadius.toVector());
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.opacityLocation, modulation);
@@ -1376,7 +1378,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
     auto drawBlurredRegion = [&](GLTexture *blurredTexture, int vertexOffset, int currentVertexCount, float blurOffset) {
-        m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.offsetLocation, blurOffset);
+        m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.offsetLocation, blurOffset * m_upsampleOffset);
         blurredTexture->bind();
         vbo->draw(GL_TRIANGLES, vertexOffset, currentVertexCount);
     };

--- a/src/blur.h
+++ b/src/blur.h
@@ -205,6 +205,8 @@ private:
 
     QMatrix4x4 m_colorMatrix;
     int m_expandSize;
+    float m_blurRadius = 1.0f;
+    float m_upsampleOffset = 1.0f;
     size_t m_maxIterationCount = 1; // number of times the texture will be downsized to half size
     BlurPipelineSettings m_contentBlurSettings{};
     BlurPipelineSettings m_decorationBlurSettings{};

--- a/src/blur.h
+++ b/src/blur.h
@@ -181,6 +181,7 @@ private:
         int mvpMatrixLocation;
         int offsetLocation;
         int halfpixelLocation;
+        int saturationCompensationLocation;
     } m_upsamplePass;
 
     struct

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -32,6 +32,9 @@
         <entry name="BlurStrength" type="Int">
             <default>15</default>
         </entry>
+        <entry name="BlurFinetune" type="Int">
+            <default>3</default>
+        </entry>
         <entry name="NoiseStrength" type="Int">
             <default>5</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -340,6 +340,75 @@
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="labelBlurFinetuneDescription">
+         <property name="text">
+          <string>Blur finetune:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutBlurFinetune">
+         <item>
+          <spacer name="horizontalSpacerBlurFinetune">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelBlurFinetuneSharp">
+           <property name="text">
+            <string>Sharp</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="kcfg_BlurFinetune">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>10</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>5</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TickPosition::TicksBelow</enum>
+           </property>
+           <property name="toolTip">
+            <string>Tunes both the downsample radius and the upsample blend together. Lower = tighter / sharper blur, higher = wider / softer blur.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelBlurFinetuneSoft">
+           <property name="text">
+            <string>Soft</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -52,7 +52,7 @@ void BlurSettings::read()
     general.saturation = BlurConfig::saturation();
     general.contrast = BlurConfig::contrast();
 
-    const float finetune = 0.5f + std::clamp(BlurConfig::blurFinetune(), 0, 10) * 0.1f;
+    const float finetune = 0.5f + std::clamp(BlurConfig::blurFinetune(), 0, 10) * 0.13f;
     general.blurRadius = finetune;
     general.upsampleOffset = finetune;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,6 +1,8 @@
 #include "settings.h"
 #include "blurconfig.h"
 
+#include <algorithm>
+
 namespace KWin
 {
 
@@ -49,6 +51,11 @@ void BlurSettings::read()
     general.brightness = BlurConfig::brightness();
     general.saturation = BlurConfig::saturation();
     general.contrast = BlurConfig::contrast();
+
+    const float finetune = 0.5f + std::clamp(BlurConfig::blurFinetune(), 0, 10) * 0.1f;
+    general.blurRadius = finetune;
+    general.upsampleOffset = finetune;
+
     general.tintColor = BlurConfig::tintColor();
     general.glowColor = BlurConfig::glowColor();
     general.edgeLighting = BlurConfig::edgeLighting();

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,6 +25,8 @@ struct GeneralSettings
     float brightness;
     float saturation;
     float contrast;
+    float blurRadius;
+    float upsampleOffset;
     QString tintColor;
     QString glowColor;
     bool edgeLighting;

--- a/src/shaders/downsample.glsl
+++ b/src/shaders/downsample.glsl
@@ -7,10 +7,15 @@ VARYING_IN vec2 uv;
 void main(void)
 {
     vec4 sum = TEXTURE(texUnit, uv) * 4.0;
-    sum += TEXTURE(texUnit, uv - halfpixel.xy * offset);
-    sum += TEXTURE(texUnit, uv + halfpixel.xy * offset);
-    sum += TEXTURE(texUnit, uv + vec2(halfpixel.x, -halfpixel.y) * offset);
-    sum += TEXTURE(texUnit, uv - vec2(halfpixel.x, -halfpixel.y) * offset);
 
-    FRAG_COLOR = sum / 8.0;
+    sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x * 2.0, 0.0) * offset);
+    sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x, halfpixel.y) * offset) * 2.0;
+    sum += TEXTURE(texUnit, uv + vec2(0.0, halfpixel.y * 2.0) * offset);
+    sum += TEXTURE(texUnit, uv + vec2(halfpixel.x, halfpixel.y) * offset) * 2.0;
+    sum += TEXTURE(texUnit, uv + vec2(halfpixel.x * 2.0, 0.0) * offset);
+    sum += TEXTURE(texUnit, uv + vec2(halfpixel.x, -halfpixel.y) * offset) * 2.0;
+    sum += TEXTURE(texUnit, uv + vec2(0.0, -halfpixel.y * 2.0) * offset);
+    sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x, -halfpixel.y) * offset) * 2.0;
+
+    FRAG_COLOR = sum / 16.0;
 }

--- a/src/shaders/upsample.glsl
+++ b/src/shaders/upsample.glsl
@@ -6,7 +6,9 @@ VARYING_IN vec2 uv;
 
 void main(void)
 {
-    vec4 sum = TEXTURE(texUnit, uv + vec2(-halfpixel.x * 2.0, 0.0) * offset);
+    vec4 sum = TEXTURE(texUnit, uv) * 4.0;
+
+    sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x * 2.0, 0.0) * offset);
     sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x, halfpixel.y) * offset) * 2.0;
     sum += TEXTURE(texUnit, uv + vec2(0.0, halfpixel.y * 2.0) * offset);
     sum += TEXTURE(texUnit, uv + vec2(halfpixel.x, halfpixel.y) * offset) * 2.0;
@@ -15,5 +17,5 @@ void main(void)
     sum += TEXTURE(texUnit, uv + vec2(0.0, -halfpixel.y * 2.0) * offset);
     sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x, -halfpixel.y) * offset) * 2.0;
 
-    FRAG_COLOR = sum / 12.0;
+    FRAG_COLOR = sum / 16.0;
 }

--- a/src/shaders/upsample.glsl
+++ b/src/shaders/upsample.glsl
@@ -22,7 +22,7 @@ void main(void)
 
     if (saturationCompensation > 1.001) {
         float luma = dot(sum.rgb, vec3(0.2126, 0.7152, 0.0722));
-        float lumaWeight = smoothstep(0.05, 0.35, luma);
+        float lumaWeight = smoothstep(0.04, 0.25, luma);
         float effectiveBoost = mix(1.0, saturationCompensation, lumaWeight);
         sum.rgb = mix(vec3(luma), sum.rgb, effectiveBoost);
     }

--- a/src/shaders/upsample.glsl
+++ b/src/shaders/upsample.glsl
@@ -1,6 +1,7 @@
 uniform sampler2D texUnit;
 uniform float offset;
 uniform vec2 halfpixel;
+uniform float saturationCompensation;
 
 VARYING_IN vec2 uv;
 
@@ -17,5 +18,14 @@ void main(void)
     sum += TEXTURE(texUnit, uv + vec2(0.0, -halfpixel.y * 2.0) * offset);
     sum += TEXTURE(texUnit, uv + vec2(-halfpixel.x, -halfpixel.y) * offset) * 2.0;
 
-    FRAG_COLOR = sum / 16.0;
+    sum /= 16.0;
+
+    if (saturationCompensation > 1.001) {
+        float luma = dot(sum.rgb, vec3(0.2126, 0.7152, 0.0722));
+        float lumaWeight = smoothstep(0.05, 0.35, luma);
+        float effectiveBoost = mix(1.0, saturationCompensation, lumaWeight);
+        sum.rgb = mix(vec3(luma), sum.rgb, effectiveBoost);
+    }
+
+    FRAG_COLOR = sum;
 }


### PR DESCRIPTION
A blur quality pass focused on the dual-Kawase pipeline. Default look changes a little.

## What's new

- **Blur finetune slider** in the General tab. Scales the blur radius for both the down- and upsample passes together. Let you reach softer or sharper blur without changing the main Blur strength slider.
- **Symmetric blur kernels.** The down- and upsample passes now use the same sample pattern, instead of a harsher one, leading to overall smoother blur.
- **Saturation compensation on the final upsample.** Counters the desaturation introduced by averaging samples at high blur radius.