### PR TITLE
Color-Compensation addition

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1289,7 +1289,9 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
         m_upsamplePass.shader->setUniform(m_upsamplePass.mvpMatrixLocation, projectionMatrix);
         m_upsamplePass.shader->setUniform(m_upsamplePass.offsetLocation, settings.offset * m_upsampleOffset);
 
-        const float upsampleSaturationBoost = 1.18f + 0.13f * (m_blurRadius + m_upsampleOffset) * 0.5f;
+        const float upsampleSaturationBoost = m_settings.general.saturationCompensation
+            ? (1.18f + 0.13f * (m_blurRadius + m_upsampleOffset) * 0.5f)
+            : 1.0f;
 
         for (size_t i = settings.iterationCount; i > 1; --i) {
             GLFramebuffer::popFramebuffer();

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -35,6 +35,9 @@
         <entry name="BlurFinetune" type="Int">
             <default>3</default>
         </entry>
+        <entry name="BlurSaturationCompensation" type="Bool">
+            <default>true</default>
+        </entry>
         <entry name="NoiseStrength" type="Int">
             <default>5</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -409,6 +409,16 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="kcfg_BlurSaturationCompensation">
+         <property name="text">
+          <string>Preserve color vibrancy in blur</string>
+         </property>
+         <property name="toolTip">
+          <string>Blur slightly desaturates colors — this counters that. Can cause artifacts.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -55,6 +55,7 @@ void BlurSettings::read()
     const float finetune = 0.5f + std::clamp(BlurConfig::blurFinetune(), 0, 10) * 0.13f;
     general.blurRadius = finetune;
     general.upsampleOffset = finetune;
+    general.saturationCompensation = BlurConfig::blurSaturationCompensation();
 
     general.tintColor = BlurConfig::tintColor();
     general.glowColor = BlurConfig::glowColor();

--- a/src/settings.h
+++ b/src/settings.h
@@ -27,6 +27,7 @@ struct GeneralSettings
     float contrast;
     float blurRadius;
     float upsampleOffset;
+    bool saturationCompensation;
     QString tintColor;
     QString glowColor;
     bool edgeLighting;


### PR DESCRIPTION
I noticed that the color compenstaion I added with my last PR can cause artifacts in regions KWin don't actively draws to (e.g the Spacer between Virutal Desktops while switching between them)

This can cause artifacts like these:

https://github.com/user-attachments/assets/3bb36384-eb89-4202-9020-7c53ebe9de8a

Since I had no easy fix for that right now, i added a checkbox to disable the feature. 
Its still enabled by defautl.