### PR TITLE
Opt-in OKLab saturation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(kcm)
 # Read compat preambles
 file(READ shaders/compat_core.glsl COMPAT_CORE)
 file(READ shaders/compat_legacy.glsl COMPAT_LEGACY)
+file(READ shaders/oklab.glsl OKLAB_SHADER)
 file(READ shaders/snells-glass.glsl SNELLS_GLASS_SHADER)
 file(READ shaders/glass.glsl GLASS_SHADER)
 
@@ -17,8 +18,9 @@ string(REPLACE "#include \"snells-glass.glsl\"" "${SNELLS_GLASS_SHADER}" GLASS_S
 function(generate_shader_variants input_glsl output_base)
     file(READ "${input_glsl}" SHADER_SRC)
 
-    # Expand glass.glsl includes
-    string(REPLACE "#include \"glass.glsl\"" "${GLASS_SHADER}" SHADER_SRC_EXPANDED "${SHADER_SRC}")
+    # Expand helper-shader includes
+    string(REPLACE "#include \"oklab.glsl\"" "${OKLAB_SHADER}" SHADER_SRC_EXPANDED "${SHADER_SRC}")
+    string(REPLACE "#include \"glass.glsl\"" "${GLASS_SHADER}" SHADER_SRC_EXPANDED "${SHADER_SRC_EXPANDED}")
 
     # Core variant
     file(WRITE "generated/${output_base}_core${ARGN}" "${COMPAT_CORE}\n${SHADER_SRC_EXPANDED}")

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -115,6 +115,8 @@ BlurEffect::BlurEffect()
     } else {
         m_roundedOnscreenPass.mvpMatrixLocation = m_roundedOnscreenPass.shader->uniformLocation("modelViewProjectionMatrix");
         m_roundedOnscreenPass.colorMatrixLocation = m_roundedOnscreenPass.shader->uniformLocation("colorMatrix");
+        m_roundedOnscreenPass.useOklabSaturationLocation = m_roundedOnscreenPass.shader->uniformLocation("useOklabSaturation");
+        m_roundedOnscreenPass.saturationLocation = m_roundedOnscreenPass.shader->uniformLocation("saturation");
         m_roundedOnscreenPass.offsetLocation = m_roundedOnscreenPass.shader->uniformLocation("offset");
         m_roundedOnscreenPass.halfpixelLocation = m_roundedOnscreenPass.shader->uniformLocation("halfpixel");
         m_roundedOnscreenPass.boxLocation = m_roundedOnscreenPass.shader->uniformLocation("box");
@@ -328,8 +330,12 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
     });
     m_blurRadius = m_settings.general.blurRadius;
     m_upsampleOffset = m_settings.general.upsampleOffset;
+
+    // If oklab saturation is enabled, the matrix should have a 
+    // saturation value of 1.0 since the saturation is handled by the shader.
+    const qreal matrixSaturation = m_settings.general.oklabSaturation ? 1.0 : m_settings.general.saturation;
     m_colorMatrix = colorTransformMatrix(
-        m_settings.general.saturation,
+        matrixSaturation,
         m_settings.general.contrast,
         m_settings.general.brightness
     );
@@ -1337,6 +1343,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.mvpMatrixLocation, projectionMatrix);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.colorMatrixLocation, colorMatrix);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.useOklabSaturationLocation, m_settings.general.oklabSaturation ? 1 : 0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.saturationLocation, static_cast<float>(m_settings.general.saturation));
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.halfpixelLocation, halfpixel);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.offsetLocation, combinedBlurSettings.offset * m_upsampleOffset);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.boxLocation, QVector4D(nativeBox.x() + nativeBox.width() * 0.5, nativeBox.y() + nativeBox.height() * 0.5, nativeBox.width() * 0.5, nativeBox.height() * 0.5));

--- a/src/blur.h
+++ b/src/blur.h
@@ -145,6 +145,8 @@ private:
         std::unique_ptr<GLShader> shader;
         int mvpMatrixLocation;
         int colorMatrixLocation;
+        int useOklabSaturationLocation;
+        int saturationLocation;
         int offsetLocation;
         int halfpixelLocation;
         int boxLocation;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -127,6 +127,9 @@ class3</default>
         <entry name="Saturation" type="Double">
             <default>1.0</default>
         </entry>
+        <entry name="OklabSaturation" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="Brightness" type="Double">
             <default>1.0</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -477,6 +477,16 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="kcfg_OklabSaturation">
+         <property name="text">
+          <string>Apply saturation perceptually (OKLab)</string>
+         </property>
+         <property name="toolTip">
+          <string>Adjusts saturation evenly across all colors instead of in plain RGB.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="label">

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -460,6 +460,27 @@
          <item>
           <widget class="QLabel" name="label">
            <property name="text">
+            <string>Contrast</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="kcfg_Contrast">
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
             <string>Saturation</string>
            </property>
           </widget>
@@ -485,27 +506,6 @@
           <string>Adjusts saturation evenly across all colors instead of in plain RGB.</string>
          </property>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Contrast</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="kcfg_Contrast">
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <layout class="QHBoxLayout">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -51,6 +51,7 @@ void BlurSettings::read()
     general.brightness = BlurConfig::brightness();
     general.saturation = BlurConfig::saturation();
     general.contrast = BlurConfig::contrast();
+    general.oklabSaturation = BlurConfig::oklabSaturation();
 
     const float finetune = 0.5f + std::clamp(BlurConfig::blurFinetune(), 0, 10) * 0.13f;
     general.blurRadius = finetune;

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,6 +25,7 @@ struct GeneralSettings
     float brightness;
     float saturation;
     float contrast;
+    bool oklabSaturation;
     float blurRadius;
     float upsampleOffset;
     QString tintColor;

--- a/src/shaders/oklab.glsl
+++ b/src/shaders/oklab.glsl
@@ -1,0 +1,55 @@
+uniform int useOklabSaturation;
+uniform float saturation;
+
+vec3 srgbToLinear(vec3 c)
+{
+    return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));
+}
+
+vec3 linearToSrgb(vec3 c)
+{
+    return mix(c * 12.92, 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055, step(0.0031308, c));
+}
+
+
+// https://en.wikipedia.org/wiki/Oklab_color_space#Conversions_between_color_spaces
+vec3 linearToOklab(vec3 c)
+{
+    float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+    float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+    float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+
+    float l_ = pow(max(l, 0.0), 1.0 / 3.0);
+    float m_ = pow(max(m, 0.0), 1.0 / 3.0);
+    float s_ = pow(max(s, 0.0), 1.0 / 3.0);
+
+    return vec3(
+        0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+        1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+        0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+    );
+}
+
+vec3 oklabToLinear(vec3 c)
+{
+    float l_ = c.r + 0.3963377774 * c.g + 0.2158037573 * c.b;
+    float m_ = c.r - 0.1055613458 * c.g - 0.0638541728 * c.b;
+    float s_ = c.r - 0.0894841775 * c.g - 1.2914855480 * c.b;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    return vec3(
+         4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+        -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+        -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s
+    );
+}
+
+vec3 oklabSaturate(vec3 srgb, float saturation)
+{
+    vec3 lab = linearToOklab(srgbToLinear(srgb));
+    lab.gb *= saturation;
+    return linearToSrgb(clamp(oklabToLinear(lab), 0.0, 1.0));
+}

--- a/src/shaders/oklab.glsl
+++ b/src/shaders/oklab.glsl
@@ -49,7 +49,10 @@ vec3 oklabToLinear(vec3 c)
 
 vec3 oklabSaturate(vec3 srgb, float saturation)
 {
-    vec3 lab = linearToOklab(srgbToLinear(srgb));
+    if (abs(saturation - 1.0) < 0.001) {
+        return srgb;
+    }
+    vec3 lab = linearToOklab(srgbToLinear(clamp(srgb, 0.0, 1.0)));
     lab.gb *= saturation;
     return linearToSrgb(clamp(oklabToLinear(lab), 0.0, 1.0));
 }

--- a/src/shaders/onscreen_rounded.glsl
+++ b/src/shaders/onscreen_rounded.glsl
@@ -11,8 +11,8 @@ uniform vec2 blurSize;
 
 VARYING_IN vec2 uv;
 VARYING_IN vec2 vertex;
-
 #include "glass.glsl"
+#include "oklab.glsl"
 
 void main(void)
 {
@@ -40,6 +40,10 @@ void main(void)
     float f = sdfRoundedBox(vertex, box.xy, box.zw, cornerRadius);
     float df = fwidth(f);
     sum *= 1.0 - clamp(0.5 + f / df, 0.0, 1.0);
+
+    if (useOklabSaturation == 1) {
+        sum.rgb = oklabSaturate(sum.rgb, saturation);
+    }
 
     FRAG_COLOR = sum * colorMatrix * opacity;
 }


### PR DESCRIPTION
Adds a checkbox in the General tab that runs the Saturation slider through OKLab instead of plain RGB. Off by default, so nothing changes unless you tick it.

## Why

Compared to the normal saturation, OKLab preserves the hue of the color more naturally. Plain RGB saturation tends to drift toward blue and purple at higher values. OKLab keeps each color recognizably itself, just more vivid.

https://en.wikipedia.org/wiki/Oklab_color_space

## What's new

- **`Apply saturation perceptually (OKLab)` checkbox** sits right under the Saturation field.
- New `src/shaders/oklab.glsl` carrying the OKLab forward/inverse math, sRGB↔linear conversion, and a small `oklabSaturate(rgb, amount)` helper.
- The shader applies the slider per-pixel when the checkbox is on; the C++ color matrix handles it the old way when off. No cost when unchecked.