### PR TITLE
Physically Based Refraction - General Improvments

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -128,6 +128,7 @@ BlurEffect::BlurEffect()
         m_roundedOnscreenPass.refractionNormalPowLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionNormalPow");
         m_roundedOnscreenPass.refractionRGBFringingLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionRGBFringing");
         m_roundedOnscreenPass.refractionOffsetStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionOffsetStrength");
+        m_roundedOnscreenPass.refractionBevelIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionBevelIntensity");
         m_roundedOnscreenPass.physicallyBasedRefractionLocation = m_roundedOnscreenPass.shader->uniformLocation("physicallyBasedRefraction");
         m_roundedOnscreenPass.tintColorLocation = m_roundedOnscreenPass.shader->uniformLocation("tintColor");
         m_roundedOnscreenPass.tintStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("tintStrength");
@@ -1358,6 +1359,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionNormalPowLocation, m_settings.refraction.refractionNormalPow);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionRGBFringingLocation, m_settings.refraction.refractionRGBFringing);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionOffsetStrengthLocation, m_settings.refraction.refractionOffsetStrength);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionBevelIntensityLocation, m_settings.refraction.refractionBevelIntensity);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.physicallyBasedRefractionLocation, m_settings.refraction.physicallyBased ? 1 : 0);
 
     QColor tint(m_settings.general.tintColor);

--- a/src/blur.h
+++ b/src/blur.h
@@ -159,6 +159,7 @@ private:
         int refractionNormalPowLocation;
         int refractionRGBFringingLocation;
         int refractionOffsetStrengthLocation;
+        int refractionBevelIntensityLocation;
         int physicallyBasedRefractionLocation;
 
         int tintColorLocation;

--- a/src/blur.kcfg
+++ b/src/blur.kcfg
@@ -154,6 +154,9 @@ class3</default>
         <entry name="RefractionOffsetStrength" type="Double">
             <default>8.0</default>
         </entry>
+        <entry name="RefractionBevelIntensity" type="Int">
+            <default>10</default>
+        </entry>
         <entry name="PhysicallyBasedRefraction" type="Bool">
             <default>false</default>
         </entry>

--- a/src/kcm/blur_config.ui
+++ b/src/kcm/blur_config.ui
@@ -1126,6 +1126,87 @@
         </layout>
        </item>
        <item>
+        <widget class="QLabel" name="labelRefractionBevelIntensity">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Bevel Intensity:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutRefractionBevelIntensity">
+         <item>
+          <spacer name="horizontalSpacerRefractionBevelIntensity">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionBevelIntensityFlat">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Flat</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="kcfg_RefractionBevelIntensity">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>5</number>
+           </property>
+           <property name="maximum">
+            <number>15</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="pageStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>10</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TickPosition::TicksBelow</enum>
+           </property>
+           <property name="toolTip">
+            <string>Scales the silhouette tilt — higher gives a more pronounced rounded-over edge.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelRefractionBevelIntensityRound">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Round</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -1443,6 +1524,30 @@
    <sender>kcfg_PhysicallyBasedRefraction</sender>
    <signal>toggled(bool)</signal>
    <receiver>labelRefractionOffsetStrengthStrong</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>kcfg_RefractionBevelIntensity</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionBevelIntensity</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionBevelIntensityFlat</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>kcfg_PhysicallyBasedRefraction</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>labelRefractionBevelIntensityRound</receiver>
    <slot>setEnabled(bool)</slot>
   </connection>
  </connections>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -90,6 +90,7 @@ void BlurSettings::read()
     refraction.refractionNormalPow = BlurConfig::refractionNormalPow() / 2.0;
     refraction.refractionRGBFringing = BlurConfig::refractionRGBFringing() / 20.0;
     refraction.refractionOffsetStrength = BlurConfig::refractionOffsetStrength() / 2.0;
+    refraction.refractionBevelIntensity = BlurConfig::refractionBevelIntensity() / 10.0;
     refraction.physicallyBased = BlurConfig::physicallyBasedRefraction();
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -70,6 +70,7 @@ struct RefractionSettings
     float refractionNormalPow;
     float refractionRGBFringing;
     float refractionOffsetStrength;
+    float refractionBevelIntensity;
     bool physicallyBased;
 };
 

--- a/src/shaders/glass.glsl
+++ b/src/shaders/glass.glsl
@@ -9,6 +9,7 @@ uniform float refractionStrength;
 uniform float refractionNormalPow;
 uniform float refractionRGBFringing;
 uniform float refractionOffsetStrength;
+uniform float refractionBevelIntensity;
 uniform int physicallyBasedRefraction;
 
 float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)

--- a/src/shaders/snells-glass.glsl
+++ b/src/shaders/snells-glass.glsl
@@ -34,11 +34,11 @@ GlassFragment snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadi
     vec2 smoothGrad = vec2(dxp - dxn, dyp - dyn);
     float gradLen = length(smoothGrad);
 
-    float normalHeight = min(concaveFactor * 0.4, 0.25);
+    float normalHeight = min(concaveFactor * 0.4, 0.25) * refractionBevelIntensity;
     vec2 normalXY = gradLen > 0.001 ? (smoothGrad / gradLen) * normalHeight : vec2(0.0);
     vec3 glassNormal = normalize(vec3(normalXY, 1.0));
 
-    float lensMagnitude = concaveFactor * bandWidth;
+    float lensMagnitude = concaveFactor * bandWidth * refractionBevelIntensity;
     vec2 surfaceNormal = gradLen > 0.001 ? smoothGrad / gradLen : vec2(1.0, 0.0);
 
     vec2 normalizedPos = position / blurSize;

--- a/src/shaders/snells-glass.glsl
+++ b/src/shaders/snells-glass.glsl
@@ -1,17 +1,16 @@
-vec4 processSample(sampler2D tex, vec2 baseUv, vec3 glassNormal, float ior, float dispersion, float bandWidth, vec2 uvScale, vec2 lensShift)
+vec4 processSample(sampler2D tex, vec2 baseUv, vec3 glassNormal, float ior, float dispersion, float magnitude, vec2 uvScale, vec2 lensShift)
 {
     vec3 viewRay = vec3(0.0, 0.0, -1.0);
 
     vec3 refractG = refract(viewRay, glassNormal, 1.0 / ior);
-    vec2 shiftG = (-refractG.xy / max(abs(refractG.z), 0.001)) * bandWidth * uvScale + lensShift;
+    vec2 dir = length(refractG.xy) > 0.001 ? normalize(refractG.xy) : vec2(0.0);
+    vec2 shiftG = dir * magnitude * uvScale + lensShift;
     vec4 sampleG = TEXTURE(tex, clamp(baseUv + shiftG, 0.0, 1.0));
 
     if (dispersion > 0.001) {
-        vec3 refractR = refract(viewRay, glassNormal, 1.0 / (ior - dispersion));
-        vec2 shiftR = (-refractR.xy / max(abs(refractR.z), 0.001)) * bandWidth * uvScale + lensShift;
-
-        vec3 refractB = refract(viewRay, glassNormal, 1.0 / (ior + dispersion));
-        vec2 shiftB = (-refractB.xy / max(abs(refractB.z), 0.001)) * bandWidth * uvScale + lensShift;
+        float fringe = clamp(dispersion, 0.0, 1.0) * 0.3;
+        vec2 shiftR = dir * (magnitude * (1.0 + fringe)) * uvScale + lensShift;
+        vec2 shiftB = dir * (magnitude * (1.0 - fringe)) * uvScale + lensShift;
 
         float r = TEXTURE(tex, clamp(baseUv + shiftR, 0.0, 1.0)).r;
         float b = TEXTURE(tex, clamp(baseUv + shiftB, 0.0, 1.0)).b;
@@ -33,8 +32,8 @@ GlassFragment snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadi
     float dyn = roundedRectangleDist(position - vec2(0.0, eps), halfBlurSize, cornerRadius);
     vec2 smoothGrad = vec2(dxp - dxn, dyp - dyn);
     float gradLen = length(smoothGrad);
-
-    float normalHeight = min(concaveFactor * 0.4, 0.25) * refractionBevelIntensity;
+    
+    float normalHeight = concaveFactor * refractionBevelIntensity;
     vec2 normalXY = gradLen > 0.001 ? (smoothGrad / gradLen) * normalHeight : vec2(0.0);
     vec3 glassNormal = normalize(vec3(normalXY, 1.0));
 
@@ -48,7 +47,8 @@ GlassFragment snellsRefraction(vec2 position, vec2 halfBlurSize, vec4 cornerRadi
     vec2 uvScale = 1.0 / blurSize;
     vec2 lensShift = -surfaceNormal * lensMagnitude * uvScale;
 
-    vec4 color = processSample(texUnit, uv, glassNormal, ior, refractionRGBFringing, bandWidth, uvScale, lensShift);
+    float refractionMagnitude = lensMagnitude * refractionStrength;
+    vec4 color = processSample(texUnit, uv, glassNormal, ior, refractionRGBFringing, refractionMagnitude, uvScale, lensShift);
 
     return GlassFragment(color, dist, edgeFactor, concaveFactor, glassNormal, ior);
 }


### PR DESCRIPTION
Some follow-up improvements on the physically based refraction shader:

## Whats new?

- Added "Bevel Intensity" Slider: Allows for finer control over the offset without changing the edge width.
- Fixed Refraction Falloff: Resolved the issue with the refraction falloff calculation (this should fix #83).