### PR TITLE
Fix blur artifacts introduced in KWin 6.7

### DIFF
--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1127,7 +1127,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
                                              backgroundRect.width() * viewport.scale(),
                                              backgroundRect.height() * viewport.scale());
     const QRect scaledBackgroundRect = snapToPixelGrid(scaledLogicalBackgroundRect);
-    const QRect deviceBackgroundRect = viewport.mapToDeviceCoordinatesAligned(Rect(backgroundRect));
+    const QRect deviceBackgroundRect = viewport.mapToDeviceCoordinates(Rect(backgroundRect)).rounded();
 #endif
     const auto opacity = data.opacity();
 


### PR DESCRIPTION
I noticed some visual blur artifacts under specific conditions. For example, when a tooltip vanishes, a small, unblurred 1px-wide color strip remains on the screen.

After digging into the KWin blur effect codebase, I traced the issue to the logic here:
https://invent.kde.org/plasma/kwin/-/blob/master/src/plugins/blur/blur.cpp?ref_type=heads#L576

This patch addresses the rounding/padding issue and seems to fix the artifact.